### PR TITLE
Tenant Snapshot, bug smashing, minor improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,10 +27,14 @@ bin/
 log/
 out/
 target/
+builder.sh
 
 # IntelliJ IDEA files
 .idea/
 *.iml
+
+# VS Code files
+.vscode/
 
 # Eclipse files
 .project

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,13 @@
 trigger:
-- main
+  branches:
+    include:
+      - main
+  paths:
+    exclude:
+      - docs
+      - licenses
+
+pr: none
 
 pool:
   vmImage: 'ubuntu-latest'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ steps:
     command: 'buildAndPush'
     Dockerfile: 'src/main/docker/lite.Dockerfile'
     buildContext: '.'
-    tags: 2.2.1-lite  # FLASHPIPE_VERSION
+    tags: 2.2.2-lite  # FLASHPIPE_VERSION
 # Full version with Maven
 - task: Docker@2
   inputs:
@@ -33,4 +33,4 @@ steps:
     command: 'buildAndPush'
     Dockerfile: 'src/main/docker/Dockerfile'
     buildContext: '.'
-    tags: 2.2.1  # FLASHPIPE_VERSION
+    tags: 2.2.2  # FLASHPIPE_VERSION

--- a/docs/azure-pipelines-upload.md
+++ b/docs/azure-pipelines-upload.md
@@ -106,7 +106,7 @@ variables:
 resources:
   containers:
     - container: flashpipe
-      image: engswee/flashpipe:2.2.1-lite
+      image: engswee/flashpipe:2.2.2-lite
 
 jobs:
   - job: build

--- a/docs/oauth_client.md
+++ b/docs/oauth_client.md
@@ -10,6 +10,7 @@ Create/edit design time artifacts | `WebToolingWorkspace.Write`, `WebToolingWork
 Configure artifacts | `WebTooling.IntegrationFlowConfigure` | `WorkspacePackagesConfigure`
 Deploy artifacts to runtime | `NodeManager.deploycontent`, `GenerationAndBuild.generationandbuildcontent` | `WorkspaceArtifactsDeploy`
 Monitor runtime artifacts | `IntegrationOperationServer.read`, `NodeManager.read` | `MonitoringDataRead`
+Read content protected by Access Policies (Optional) |`AccessPoliciesArtifacts.AccessAll`|`AccessAllAccessPoliciesArtifacts`
 
 ## OAuth Client setup
 - [OAuth Client on Cloud Foundry](#CF)

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.github.engswee</groupId>
     <artifactId>flashpipe</artifactId>
     <!-- FLASHPIPE_VERSION -->
-    <version>2.2.1</version>
+    <version>2.2.2</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -42,7 +42,7 @@ RUN mvn -B -f /tmp/pom.xml -s /usr/share/maven/ref/settings-docker.xml dependenc
 # 4 - Copy JAR file used for accessing CPI APIs
 # ----------------------------------------
 # <FLASHPIPE_VERSION>
-ARG FLASHPIPE_VERSION=2.2.1
+ARG FLASHPIPE_VERSION=2.2.2
 COPY target/flashpipe-${FLASHPIPE_VERSION}.jar /tmp/flashpipe-${FLASHPIPE_VERSION}.jar
 RUN mvn -s /usr/share/maven/ref/settings-docker.xml install:install-file -DgroupId=io.github.engswee -DartifactId=flashpipe -Dversion=${FLASHPIPE_VERSION} -Dpackaging=jar -Dfile=/tmp/flashpipe-${FLASHPIPE_VERSION}.jar
 

--- a/src/main/docker/lite.Dockerfile
+++ b/src/main/docker/lite.Dockerfile
@@ -52,7 +52,7 @@ RUN mkdir -p       ${MAVEN_REPO_DIR}/org/zeroturnaround/zt-zip/${ZT_ZIP_VER} \
 # ----------------------------------------
 # 3 - Copy FlashPipe JAR file used for accessing CPI APIs
 # ----------------------------------------
-ARG FLASHPIPE_VERSION=2.2.1
+ARG FLASHPIPE_VERSION=2.2.2
 RUN mkdir -p ${MAVEN_REPO_DIR}/io/github/engswee/flashpipe/${FLASHPIPE_VERSION}
 COPY target/flashpipe-${FLASHPIPE_VERSION}.jar ${MAVEN_REPO_DIR}/io/github/engswee/flashpipe/${FLASHPIPE_VERSION}/flashpipe-${FLASHPIPE_VERSION}.jar
 

--- a/src/main/docker/script/set_classpath.sh
+++ b/src/main/docker/script/set_classpath.sh
@@ -1,5 +1,5 @@
 echo "[INFO] Setting WORKING_CLASSPATH environment variable"
-FLASHPIPE_VERSION=2.2.1
+FLASHPIPE_VERSION=2.2.2
 export WORKING_CLASSPATH=/usr/share/maven/ref/repository/io/github/engswee/flashpipe/$FLASHPIPE_VERSION/flashpipe-$FLASHPIPE_VERSION.jar
 export WORKING_CLASSPATH=$WORKING_CLASSPATH:/usr/share/maven/ref/repository/org/codehaus/groovy/groovy-all/2.4.21/groovy-all-2.4.21.jar
 export WORKING_CLASSPATH=$WORKING_CLASSPATH:/usr/share/maven/ref/repository/org/apache/httpcomponents/core5/httpcore5/5.0.4/httpcore5-5.0.4.jar

--- a/src/main/docker/script/sync_to_git_repository.sh
+++ b/src/main/docker/script/sync_to_git_repository.sh
@@ -51,6 +51,37 @@ function exec_java_command() {
 }
 
 # ----------------------------------------------------------------
+# Parse arguments, overriding existing environment variables
+# ----------------------------------------------------------------
+echo "[INFO] parsing arguments"
+for ARGUMENT in "$@"
+do  
+    KEY=$(echo $ARGUMENT | cut -f1 -d=)
+    VALUE=$(echo $ARGUMENT | cut -f2 -d=)   
+
+    case "$KEY" in
+            HOST_TMN)        HOST_TMN=${VALUE} ;;
+            BASIC_USERID)    BASIC_USERID=${VALUE} ;;     
+            BASIC_PASSWORD)  BASIC_PASSWORD=${VALUE} ;;
+            HOST_OAUTH)      HOST_OAUTH=${VALUE} ;;
+            HOST_OAUTH_PATH) HOST_OAUTH_PATH=${VALUE} ;;
+            OAUTH_CLIENTID)  OAUTH_CLIENTID=${VALUE} ;;
+            OAUTH_CLIENTSECRET) OAUTH_CLIENTSECRET=${VALUE} ;;           
+            LOG4J_FILE)      LOG4J_FILE=${VALUE} ;;
+            PACKAGE_ID)      PACKAGE_ID=${VALUE} ;;
+            GIT_SRC_DIR)     GIT_SRC_DIR=${VALUE} ;;
+            DRAFT_HANDLING)  DRAFT_HANDLING=${VALUE} ;;
+            INCLUDE_IDS)     INCLUDE_IDS=${VALUE} ;;
+            EXCLUDE_IDS)     EXCLUDE_IDS=${VALUE} ;;
+            WORK_DIR)        WORK_DIR=${VALUE} ;;
+            DIR_NAMING_TYPE) DIR_NAMING_TYPE=${VALUE} ;;
+            COMMIT_MESSAGE)  COMMIT_MESSAGE=${VALUE} ;;
+            DO_NOT_COMMIT)   DO_NOT_COMMIT=${VALUE} ;;
+            *)               echo "[INFO] Unknown argument: $ARGUMENT, ignoring"
+    esac    
+done
+
+# ----------------------------------------------------------------
 # Check presence of environment variables
 # ----------------------------------------------------------------
 check_mandatory_env_var "HOST_TMN" "$HOST_TMN"
@@ -67,6 +98,9 @@ check_mandatory_env_var "PACKAGE_ID" "$PACKAGE_ID"
 check_mandatory_env_var "GIT_SRC_DIR" "$GIT_SRC_DIR"
 if [ -z "$WORK_DIR" ]; then
   export WORK_DIR="/tmp"
+fi
+if [ -z "$DO_NOT_COMMIT" ]; then
+  export DO_NOT_COMMIT=0
 fi
 
 # Set debug log4j config
@@ -87,7 +121,7 @@ if [ -z "$CLASSPATH_DIR" ]; then
 else
   echo "[INFO] Using $CLASSPATH_DIR as classpath base directory "
   echo "[INFO] Setting WORKING_CLASSPATH environment variable"
-  FLASHPIPE_VERSION=2.2.1
+  FLASHPIPE_VERSION=2.2.2
   export WORKING_CLASSPATH=$CLASSPATH_DIR/repository/io/github/engswee/flashpipe/$FLASHPIPE_VERSION/flashpipe-$FLASHPIPE_VERSION.jar
   export WORKING_CLASSPATH=$WORKING_CLASSPATH:$CLASSPATH_DIR/repository/org/codehaus/groovy/groovy-all/2.4.12/groovy-all-2.4.12.jar
   export WORKING_CLASSPATH=$WORKING_CLASSPATH:$CLASSPATH_DIR/repository/org/apache/httpcomponents/core5/httpcore5/5.0.4/httpcore5-5.0.4.jar
@@ -100,16 +134,24 @@ else
   export WORKING_CLASSPATH=$WORKING_CLASSPATH:$CLASSPATH_DIR/repository/org/zeroturnaround/zt-zip/1.14/zt-zip-1.14.jar
 fi
 
+# Git config
+echo "[INFO] Configuring git"
+git config --global core.autocrlf input
+git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git config --local user.name "github-actions[bot]"
+
 exec_java_command io.github.engswee.flashpipe.cpi.exec.DownloadIntegrationPackageContent
 
 # Commit
-git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-git config --local user.name "github-actions[bot]"
-echo "[INFO] Adding all files for Git tracking"
-git add --all --verbose
-echo "[INFO] Trying to commit changes"
-if git commit -m "$COMMIT_MESSAGE" -a --verbose; then
-  echo "[INFO] 🏆 Changes committed"
+if [[ "$DO_NOT_COMMIT" != "1" ]]; then
+  echo "[INFO] Adding all files for Git tracking"
+  git add --all --verbose
+  echo "[INFO] Trying to commit changes"
+  if git commit -m "$COMMIT_MESSAGE" -a --verbose; then
+    echo "[INFO] 🏆 Changes committed"
+  else
+    echo "[INFO] 🏆 No changes to commit"
+  fi
 else
-  echo "[INFO] 🏆 No changes to commit"
+  echo "[INFO] 🏆 Changes not committed (DO_NOT_COMMIT=1)"
 fi

--- a/src/main/docker/script/update_designtime_artifact.sh
+++ b/src/main/docker/script/update_designtime_artifact.sh
@@ -106,7 +106,7 @@ if [ -z "$CLASSPATH_DIR" ]; then
 else
   echo "[INFO] Using $CLASSPATH_DIR as classpath base directory "
   echo "[INFO] Setting WORKING_CLASSPATH environment variable"
-  FLASHPIPE_VERSION=2.2.1
+  FLASHPIPE_VERSION=2.2.2
   export WORKING_CLASSPATH=$CLASSPATH_DIR/repository/io/github/engswee/flashpipe/$FLASHPIPE_VERSION/flashpipe-$FLASHPIPE_VERSION.jar
   export WORKING_CLASSPATH=$WORKING_CLASSPATH:$CLASSPATH_DIR/repository/org/codehaus/groovy/groovy-all/2.4.12/groovy-all-2.4.12.jar
   export WORKING_CLASSPATH=$WORKING_CLASSPATH:$CLASSPATH_DIR/repository/org/apache/httpcomponents/core5/httpcore5/5.0.4/httpcore5-5.0.4.jar

--- a/src/main/groovy/io/github/engswee/flashpipe/cpi/api/IntegrationPackage.groovy
+++ b/src/main/groovy/io/github/engswee/flashpipe/cpi/api/IntegrationPackage.groovy
@@ -107,4 +107,29 @@ class IntegrationPackage {
 
         return this.httpExecuter.getResponseBody().getText('UTF-8')
     }
+
+    boolean isReadOnly(String packageId) {
+        logger.info("Checking if package is marked as read only")
+        this.httpExecuter.executeRequest("/api/v1/IntegrationPackages('${packageId}')", ['Accept': 'application/json'])
+        def code = this.httpExecuter.getResponseCode()
+        if (code == 200) {
+            def root = new JsonSlurper().parse(this.httpExecuter.getResponseBody())
+            return (root.d.Mode.toString() == 'READ_ONLY')
+        } else {
+            logger.error("Error checking mode of Integration Package ${packageId}")
+            return false
+        }
+    }
+
+    List getPackagesList(){
+        // Get the list of packages of the current tenant
+        logger.info("Getting the list of packages of the current tenant")
+        this.httpExecuter.executeRequest("/api/v1/IntegrationPackages", ['Accept': 'application/json'])
+        def code = this.httpExecuter.getResponseCode()
+        if (code == 200) { 
+            def root = new JsonSlurper().parse(this.httpExecuter.getResponseBody())
+            return root.d.results.collect { it }
+        } else
+            this.httpExecuter.logError('Getting the list of packages of the current tenant')
+    }
 }

--- a/src/main/groovy/io/github/engswee/flashpipe/cpi/exec/DownloadIntegrationPackageContent.groovy
+++ b/src/main/groovy/io/github/engswee/flashpipe/cpi/exec/DownloadIntegrationPackageContent.groovy
@@ -50,13 +50,19 @@ class DownloadIntegrationPackageContent extends APIExecuter {
         // Get all design time artifacts of package
         logger.info("Getting artifacts in integration package ${packageId}")
         IntegrationPackage integrationPackage = new IntegrationPackage(this.httpExecuter)
+        // Verify the package is downloabable
+        if (integrationPackage.isReadOnly(packageId)) {
+            logger.info("⚠️ Package ${packageId} is not available for download, gracefully aborting")
+            System.exit(0)
+        }
+
         List artifacts = integrationPackage.getIFlowsWithDraftState(packageId)
         DesignTimeArtifact designTimeArtifact = new DesignTimeArtifact(this.httpExecuter)
 
         // Create temp directories in working dir
-        new File("${workDir}/download").mkdir()
-        new File("${workDir}/from_git").mkdir()
-        new File("${workDir}/from_tenant").mkdir()
+        new File("${workDir}/download").mkdirs()
+        new File("${workDir}/from_git").mkdirs()
+        new File("${workDir}/from_tenant").mkdirs()
 
         List filteredArtifacts = filterArtifacts(artifacts, includedIds, excludeIds)
 

--- a/src/main/groovy/io/github/engswee/flashpipe/cpi/exec/GetTenantSnapshot.groovy
+++ b/src/main/groovy/io/github/engswee/flashpipe/cpi/exec/GetTenantSnapshot.groovy
@@ -1,0 +1,97 @@
+package io.github.engswee.flashpipe.cpi.exec
+
+import io.github.engswee.flashpipe.cpi.api.IntegrationPackage
+import io.github.engswee.flashpipe.cpi.exec.DownloadIntegrationPackageContent
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.zeroturnaround.zip.ZipUtil
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
+
+class GetTenantSnapshot extends APIExecuter {
+
+    static Logger logger = LoggerFactory.getLogger(GetTenantSnapshot)
+
+    static void main(String[] args) {
+        GetTenantSnapshot GetTenantSnapshot = new GetTenantSnapshot()
+        GetTenantSnapshot.execute()
+    }
+
+    @Override
+    void execute() {
+        def gitSrcDir = getMandatoryEnvVar('GIT_SRC_DIR')
+        def host = getMandatoryEnvVar('HOST_TMN')
+        def workDir = getMandatoryEnvVar('WORK_DIR')
+        
+        // Check that input environment variables do not have any of the secrets in their values
+        validateInputContainsNoSecrets('GIT_SRC_DIR')
+        validateInputContainsNoSecrets('GIT_BRANCH') //-TODO-: Add Git branch support
+        validateInputContainsNoSecrets('COMMIT_MESSAGE')
+        
+        println '---------------------------------------------------------------------------------'
+        logger.info("📢 Begin taking a snapshot of the tenant")
+ 
+        // Get packages from the tentant        
+        logger.info("Getting the list of packages of the tenant - ${host}")
+        IntegrationPackage integrationPackage = new IntegrationPackage(this.httpExecuter)
+        List packages = integrationPackage.getPackagesList()
+        if (packages.size() == 0) {
+            logger.error("🛑 No packages found in the tenant")
+            System.exit(1)
+        }
+        
+        logger.info("Processing ${packages.size()} packages")
+        def result = new StringBuffer()
+        def error = new StringBuffer()
+        packages.eachWithIndex{it,i->
+            def index = i + 1
+            def packageId = it.Id.toString()
+            println '---------------------------------------------------------------------------------'
+            logger.info("Processing package ${index}/${packages.size()} - ID: ${packageId}")            
+
+            //Set arguments for calling the script that will download the package
+            def cmd =  [
+                "sync_to_git_repository.sh",
+                "GIT_SRC_DIR=${gitSrcDir}/packages",
+                "PACKAGE_ID=${packageId}",
+                "WORK_DIR=${workDir}/${packageId}",
+                "DO_NOT_COMMIT=1"
+            ]
+            cmd << inheritedEnvVarAsArgument('HOST_TMN')
+            cmd << inheritedEnvVarAsArgument('BASIC_USERID')
+            cmd << inheritedEnvVarAsArgument('BASIC_PASSWORD')
+            cmd << inheritedEnvVarAsArgument('HOST_OAUTH')
+            cmd << inheritedEnvVarAsArgument('HOST_OAUTH_PATH')
+            cmd << inheritedEnvVarAsArgument('OAUTH_CLIENTID')
+            cmd << inheritedEnvVarAsArgument('OAUTH_CLIENTSECRET')
+            cmd << inheritedEnvVarAsArgument('LOG4J_FILE')
+            cmd << inheritedEnvVarAsArgument('DRAFT_HANDLING')
+            cmd << inheritedEnvVarAsArgument('DIR_NAMING_TYPE')            
+            cmd = cmd.findAll() // remove empty elements
+
+            //Execute the script
+            //Download script comes with it's own logger
+            def proc = cmd.execute()
+            proc.waitForProcessOutput ( result, error )
+            if (error.length() > 0) {
+                logger.error("🛑 Error while downloading package ${index}/${packages.size()} - ID: ${it.Id}")
+                System.out << error.toString()       
+                System.out << result.toString()
+                System.exit(1)
+            }
+            System.out << result.toString()
+            result.setLength(0)
+            error.setLength(0)
+        }
+        println '---------------------------------------------------------------------------------'
+        logger.info("🏆 Completed taking a snapshot of the tenant")
+    }
+    String inheritedEnvVarAsArgument(String envVarName) {
+        def envVar = System.getenv(envVarName)
+        if (envVar == null) { return null }
+        return envVarName + "=" + envVar
+    }
+}


### PR DESCRIPTION
# Pull request 20210725-1 - Flashpipe 2.2.2

To the best of my knowledge, this pull request should not break anything. A new branch is advised.


## Smashed Bugs

### 1- Downloading READ_ONLY packages
#### Problem:
Some standard SAP Packages have an indicator (Field: Mode) with the "READ_ONLY" value. Unfortunately, it is not possible to download these packages with the current API.
#### Proposed and Implemented Solution: 
Added a new method to the class [IntegrationPackage](https://github.com/ambravo/flashpipe/blob/ab12d5042e582ce33a67f58c8d9e8c78514ecbe5/src/main/groovy/io/github/engswee/flashpipe/cpi/api/IntegrationPackage.groovy#L111) that verifies if the package has been catalogued as read-only. Then, this method is utilised in the class [DownloadIntegrationPackageContent](https://github.com/ambravo/flashpipe/blob/ab12d5042e582ce33a67f58c8d9e8c78514ecbe5/src/main/groovy/io/github/engswee/flashpipe/cpi/exec/DownloadIntegrationPackageContent.groovy#L53).

### 2- Recursive directory creation (Working Directory)
#### Problem:
The feature I have been working on requires subdirectories when using the working directory. Unfortunately, the current implementation does not support subdirectories.
#### Proposed and Implemented Solution: 
java.io.File.mkdirs() instead of java.io.File.mkdir() in [DownloadIntegrationPackageContent](https://github.com/ambravo/flashpipe/blob/ab12d5042e582ce33a67f58c8d9e8c78514ecbe5/src/main/groovy/io/github/engswee/flashpipe/cpi/exec/DownloadIntegrationPackageContent.groovy#L62)

## Small new features
### 1- Arguments to override the utilisation of environment variables
#### Rationale:
To implement one new feature, I planned to directly call DownloadIntegrationPackageContent.execute() from a new Class. There is a problem with this; the method "execute()" instead of accepting parameters uses environment variables. I find it cumbersome to set a new JVM instance to call the method with new environment variables (or... am I missing something? like a magic "System.setEnv()" in groovy?)
#### Proposed and Implemented Alternative: 
Instead of jumping to modify the class (invasive IMO), I modified the bash script that downloads packages in a non-invasive way. The script now accepts arguments that override the environment variables. [sync_to_git_repository.sh](https://github.com/ambravo/flashpipe/blob/ab12d5042e582ce33a67f58c8d9e8c78514ecbe5/src/main/docker/script/sync_to_git_repository.sh#L53)
### 2- New DO_NOT_COMMIT argument  in sync_to_git_repository.sh
#### Rationale:
To implement one new feature, instead of creating a new commit per package, I wanted to have one commit for the whole process. So this new argument executes the download/unzipping/comparison process without commit the files.
#### Proposed and Implemented Alternative: 
The new argument :) [sync_to_git_repository.sh](https://github.com/ambravo/flashpipe/blob/ab12d5042e582ce33a67f58c8d9e8c78514ecbe5/src/main/docker/script/sync_to_git_repository.sh#L146)
### 3- New IntegrationPackage.getPackagesList() to... get the list of packages!
#### Rationale:
To implement one new feature, I needed the list of packages of the tenant. I wanted to use a POJO approach (similar to the OData client generated by SAP's SDK), but I didn't particularly appreciate introducing new dependencies for a small method. Hence, this method returns a list of packages with all the information provided by the standard API call.
#### Proposed and Implemented Alternative: 
The new method :) [IntegrationPackage.getPackagesList()](https://github.com/ambravo/flashpipe/blob/ab12d5042e582ce33a67f58c8d9e8c78514ecbe5/src/main/groovy/io/github/engswee/flashpipe/cpi/api/IntegrationPackage.groovy#L124)

## New feature: Tenant Snapshot
#### Driver:
As part of my CI/CD activities, I wanted a constant process (or on-demand) that triggers a snapshot of a development tenant. Also, I needed some protection from junior developers in a large integration team (without getting into details).

#### Implemented feature
This new feature is composed of a new class ([GetTenantSnapshot](https://github.com/ambravo/flashpipe/blob/ab12d5042e582ce33a67f58c8d9e8c78514ecbe5/src/main/groovy/io/github/engswee/flashpipe/cpi/exec/GetTenantSnapshot.groovy#L14)) that calls the scrip sync_to_git_repository.sh for all the tenant packages and a new script that calls the new class, and the script [snapshot_to_git_repository.sh](https://github.com/ambravo/flashpipe/blob/ab12d5042e582ce33a67f58c8d9e8c78514ecbe5/src/main/docker/script/snapshot_to_git_repository.sh#L1) that is called by the pipeline's workflow.

#### Roadmap
- Save credential artefacts (without the passwords)
- Save the list of certificates, but without the content. The list might include the certificate fingerprint.
- Save the list of Cloud Connectors available and the resources they expose.
- Save the list of created roles. (Management and Runtime)

#### TO-DOs
TODOs are marked with the tag "-TODO-" in the code.
- Time zone in the default commit message.
- Add support for git branches.

#### Known problems
~~Artefacts protected with Access Policies require the user or oAuth client that runs the pipeline to have that access policy role attached. Besides attaching that role, a possible workaround could be to ignore the artefacts. Notwithstanding, this problem also affects the currently implemented features.~~
Edit: I just found the following role, It would have to be attached to the user/client that calls the API:
![Trial Home  me@amba is Trial  Overview - SAP BTP Cockpit 2021-07-27 at 1 35 59 pm](https://user-images.githubusercontent.com/2177550/127173574-dd3d1d05-dcca-49d6-8dd3-26c4885897b8.jpg)


#### Sample workflow
The following configuration file is a sample workflow that leverages the new feature. (Replace the XXXXXs with your values)

```
name: Tenant Snapshot
on:
  workflow_dispatch:
    inputs:
      directory:
        description: 'Target Git directory (relative from repository root)'
        required: true
      draft:
        description: 'Draft handling (optional) - SKIP (default value if empty), ADD, ERROR'
        required: false        
      message:
        description: 'Commit message (optional)'
        required: false        
jobs:
  take_snapshot:
    runs-on: ubuntu-latest
    container:
      image: xxxxxxx/flashpipe:xxxxx
    env:
      HOST_TMN: XXXXXXXXXX
      HOST_OAUTH: dummy.authentication.eu10.hana.ondemand.com
      BASIC_USERID: ${{ secrets.DEV_USER_ID }}
      BASIC_PASSWORD: ${{ secrets.DEV_PASSWORD }}     
    steps:
    - uses: actions/checkout@v2
    - name: 'Set GIT_SRC_DIR for sync_to_git_repository.sh'
      run: |
        echo "GIT_SRC_DIR=$GITHUB_WORKSPACE/${{ github.event.inputs.directory }}" >> $GITHUB_ENV
    - name: 'Take a snapshot'
      run: /usr/bin/snapshot_to_git_repository.sh
      shell: bash
      env:
        DRAFT_HANDLING: ${{ github.event.inputs.draft }}
        COMMIT_MESSAGE: ${{ github.event.inputs.message }}
        PACKAGE_ID: "/"
    - name: Push changes
      uses: ad-m/github-push-action@master
      with:
        github_token: ${{ secrets.GITHUB_TOKEN }}
        branch: ${{ github.ref }}
```

#### Tests

All the tests were done using a currently private image (abravoayala/flashpipe:latest) and a Neo tenant (EU2) with circa 80 packages and +400 iflows. Under these parameters, the executions took about an average of 12  minutes to execute.

![Sync repo from tenant · amba-cpi-tests-fp@c730abc 2021-07-25 at 10 42 59 pm](https://user-images.githubusercontent.com/2177550/126914408-fe6a4814-f14f-4703-b694-669c2cdd28f6.jpg)


## Outro

Other suggestions and questions will be added to the issues of the official Flashpipe repo for a wider discussion.

Topics:
- Tag management in docker hub
- Integration packages details as object's attributes
- Logger with a debug option
- Branch management
- Workflows examples in the main repo
- Downloading elements protected with access Policies
- (Parameter) Force Push - Rebase options
- (Parameter) Git Ignore / Configuration


## Authors

- Ariel Bravo-Ayala [@ambravo](https://github.com/ambravo) // https://amba.is

  Signed-off-by: Ariel Bravo-Ayala <me@amba.is>