### PR TITLE
Add support for environment variables substitution in dir-* configuration parameters

### DIFF
--- a/internal/cmd/apim.go
+++ b/internal/cmd/apim.go
@@ -2,6 +2,11 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
 	"github.com/engswee/flashpipe/internal/analytics"
 	"github.com/engswee/flashpipe/internal/api"
 	"github.com/engswee/flashpipe/internal/config"
@@ -11,14 +16,9 @@ import (
 	"github.com/go-errors/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	"os"
-	"path/filepath"
-	"strings"
-	"time"
 )
 
 func NewAPIMCommand() *cobra.Command {
-
 	apimCmd := &cobra.Command{
 		Use:   "apim",
 		Short: "Sync API Management artifacts between tenant and Git",
@@ -26,9 +26,9 @@ func NewAPIMCommand() *cobra.Command {
 tenant and a Git repository.`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// If artifacts directory is provided, validate that is it a subdirectory of Git repo
-			gitRepoDir := config.GetString(cmd, "dir-git-repo")
+			gitRepoDir := config.GetDirectory(cmd, "dir-git-repo")
 			if gitRepoDir != "" {
-				artifactsDir := config.GetString(cmd, "dir-artifacts")
+				artifactsDir := config.GetDirectory(cmd, "dir-artifacts")
 				gitRepoDirClean := filepath.Clean(gitRepoDir) + string(os.PathSeparator)
 				if artifactsDir != "" && !strings.HasPrefix(artifactsDir, gitRepoDirClean) {
 					return fmt.Errorf("--dir-artifacts [%v] should be a subdirectory of --dir-git-repo [%v]", artifactsDir, gitRepoDirClean)
@@ -62,9 +62,9 @@ tenant and a Git repository.`,
 func runSyncAPIM(cmd *cobra.Command) error {
 	log.Info().Msg("Executing sync apim command")
 
-	gitRepoDir := config.GetString(cmd, "dir-git-repo")
+	gitRepoDir := config.GetDirectory(cmd, "dir-git-repo")
 	artifactsDir := config.GetStringWithDefault(cmd, "dir-artifacts", gitRepoDir)
-	workDir := config.GetString(cmd, "dir-work")
+	workDir := config.GetDirectory(cmd, "dir-work")
 	includedIds := config.GetStringSlice(cmd, "ids-include")
 	excludedIds := config.GetStringSlice(cmd, "ids-exclude")
 	commitMsg := config.GetString(cmd, "git-commit-msg")

--- a/internal/cmd/artifact.go
+++ b/internal/cmd/artifact.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/engswee/flashpipe/internal/analytics"
 	"github.com/engswee/flashpipe/internal/api"
 	"github.com/engswee/flashpipe/internal/config"
@@ -11,11 +13,9 @@ import (
 	"github.com/engswee/flashpipe/internal/sync"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	"time"
 )
 
 func NewArtifactCommand() *cobra.Command {
-
 	artifactCmd := &cobra.Command{
 		Use:   "artifact",
 		Short: "Create/update artifacts",
@@ -74,10 +74,10 @@ func runUpdateArtifact(cmd *cobra.Command) error {
 		log.Info().Msgf("Using package ID %v as package name", packageId)
 		packageName = packageId
 	}
-	artifactDir := config.GetString(cmd, "dir-artifact")
+	artifactDir := config.GetDirectory(cmd, "dir-artifact")
 	parametersFile := config.GetString(cmd, "file-param")
 	manifestFile := config.GetString(cmd, "file-manifest")
-	workDir := config.GetString(cmd, "dir-work")
+	workDir := config.GetDirectory(cmd, "dir-work")
 	scriptMap := config.GetStringSlice(cmd, "script-collection-map")
 
 	defaultParamFile := fmt.Sprintf("%v/src/main/resources/parameters.prop", artifactDir)

--- a/internal/cmd/snapshot.go
+++ b/internal/cmd/snapshot.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/engswee/flashpipe/internal/analytics"
 	"github.com/engswee/flashpipe/internal/api"
 	"github.com/engswee/flashpipe/internal/config"
@@ -9,11 +11,9 @@ import (
 	"github.com/engswee/flashpipe/internal/sync"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	"time"
 )
 
 func NewSnapshotCommand() *cobra.Command {
-
 	snapshotCmd := &cobra.Command{
 		Use:   "snapshot",
 		Short: "Snapshot integration packages from tenant to Git",
@@ -57,8 +57,8 @@ tenant to a Git repository.`,
 func runSnapshot(cmd *cobra.Command) error {
 	log.Info().Msg("Executing snapshot command")
 
-	gitRepoDir := config.GetString(cmd, "dir-git-repo")
-	workDir := config.GetString(cmd, "dir-work")
+	gitRepoDir := config.GetDirectory(cmd, "dir-git-repo")
+	workDir := config.GetDirectory(cmd, "dir-work")
 	draftHandling := config.GetString(cmd, "draft-handling")
 	commitMsg := config.GetString(cmd, "git-commit-msg")
 	commitUser := config.GetString(cmd, "git-commit-user")

--- a/internal/cmd/sync.go
+++ b/internal/cmd/sync.go
@@ -2,6 +2,11 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
 	"github.com/engswee/flashpipe/internal/analytics"
 	"github.com/engswee/flashpipe/internal/api"
 	"github.com/engswee/flashpipe/internal/config"
@@ -9,14 +14,9 @@ import (
 	"github.com/engswee/flashpipe/internal/sync"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	"os"
-	"path/filepath"
-	"strings"
-	"time"
 )
 
 func NewSyncCommand() *cobra.Command {
-
 	syncCmd := &cobra.Command{
 		Use:   "sync",
 		Short: "Sync designtime artifacts between tenant and Git",
@@ -38,9 +38,9 @@ tenant and a Git repository.`,
 				return fmt.Errorf("invalid value for --draft-handling = %v", draftHandling)
 			}
 			// If artifacts directory is provided, validate that is it a subdirectory of Git repo
-			gitRepoDir := config.GetString(cmd, "dir-git-repo")
+			gitRepoDir := config.GetDirectory(cmd, "dir-git-repo")
 			if gitRepoDir != "" {
-				artifactsDir := config.GetString(cmd, "dir-artifacts")
+				artifactsDir := config.GetDirectory(cmd, "dir-artifacts")
 				gitRepoDirClean := filepath.Clean(gitRepoDir) + string(os.PathSeparator)
 				if artifactsDir != "" && !strings.HasPrefix(artifactsDir, gitRepoDirClean) {
 					return fmt.Errorf("--dir-artifacts [%v] should be a subdirectory of --dir-git-repo [%v]", artifactsDir, gitRepoDirClean)
@@ -96,9 +96,9 @@ func runSync(cmd *cobra.Command) error {
 	log.Info().Msg("Executing sync command")
 
 	packageId := config.GetString(cmd, "package-id")
-	gitRepoDir := config.GetString(cmd, "dir-git-repo")
+	gitRepoDir := config.GetDirectory(cmd, "dir-git-repo")
 	artifactsDir := config.GetStringWithDefault(cmd, "dir-artifacts", gitRepoDir)
-	workDir := config.GetString(cmd, "dir-work")
+	workDir := config.GetDirectory(cmd, "dir-work")
 	dirNamingType := config.GetString(cmd, "dir-naming-type")
 	draftHandling := config.GetString(cmd, "draft-handling")
 	includedIds := config.GetStringSlice(cmd, "ids-include")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 )
 
@@ -29,5 +31,10 @@ func GetInt(cmd *cobra.Command, flagName string) int {
 
 func GetBool(cmd *cobra.Command, flagName string) bool {
 	val, _ := cmd.Flags().GetBool(flagName)
+	return val
+}
+
+func GetDirectory(cmd *cobra.Command, flagName string) string {
+	val := os.ExpandEnv(GetString(cmd, flagName))
 	return val
 }


### PR DESCRIPTION
Add support for environment variables substitution in dir-* configuration parameters. This feature may become useful when the configuration for FlashPipe is submitted in a configuration file rather than using command line arguments (where shell expansions can be executed implicitly and automatically by the shell).

Scope of the change:
- Introduce a new getter function that implements environment variable expansion on top of the existing string getter function,
- Use the newly introduced function when accessing directory-related configuration parameters' values.

Fixes #32 