### PR TITLE
Prevent shell expansion for env variables containing secrets

### DIFF
--- a/internal/cmd/artifact.go
+++ b/internal/cmd/artifact.go
@@ -74,10 +74,16 @@ func runUpdateArtifact(cmd *cobra.Command) error {
 		log.Info().Msgf("Using package ID %v as package name", packageId)
 		packageName = packageId
 	}
-	artifactDir := config.GetDirectory(cmd, "dir-artifact")
+	artifactDir, err := config.GetStringWithEnvExpand(cmd, "dir-artifact")
+	if err != nil {
+		return fmt.Errorf("security alert for --dir-artifact: %w", err)
+	}
 	parametersFile := config.GetString(cmd, "file-param")
 	manifestFile := config.GetString(cmd, "file-manifest")
-	workDir := config.GetDirectory(cmd, "dir-work")
+	workDir, err := config.GetStringWithEnvExpand(cmd, "dir-work")
+	if err != nil {
+		return fmt.Errorf("security alert for --dir-work: %w", err)
+	}
 	scriptMap := config.GetStringSlice(cmd, "script-collection-map")
 
 	defaultParamFile := fmt.Sprintf("%v/src/main/resources/parameters.prop", artifactDir)
@@ -125,7 +131,7 @@ func runUpdateArtifact(cmd *cobra.Command) error {
 	exe := api.InitHTTPExecuter(serviceDetails)
 
 	// Create integration package first if required
-	err := createPackage(packageId, packageName, exe)
+	err = createPackage(packageId, packageName, exe)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/sync.go
+++ b/internal/cmd/sync.go
@@ -38,9 +38,15 @@ tenant and a Git repository.`,
 				return fmt.Errorf("invalid value for --draft-handling = %v", draftHandling)
 			}
 			// If artifacts directory is provided, validate that is it a subdirectory of Git repo
-			gitRepoDir := config.GetDirectory(cmd, "dir-git-repo")
+			gitRepoDir, err := config.GetStringWithEnvExpand(cmd, "dir-git-repo")
+			if err != nil {
+				return fmt.Errorf("security alert for --dir-git-repo: %w", err)
+			}
 			if gitRepoDir != "" {
-				artifactsDir := config.GetDirectory(cmd, "dir-artifacts")
+				artifactsDir, err := config.GetStringWithEnvExpand(cmd, "dir-artifacts")
+				if err != nil {
+					return fmt.Errorf("security alert for --dir-artifacts: %w", err)
+				}
 				gitRepoDirClean := filepath.Clean(gitRepoDir) + string(os.PathSeparator)
 				if artifactsDir != "" && !strings.HasPrefix(artifactsDir, gitRepoDirClean) {
 					return fmt.Errorf("--dir-artifacts [%v] should be a subdirectory of --dir-git-repo [%v]", artifactsDir, gitRepoDirClean)
@@ -96,9 +102,18 @@ func runSync(cmd *cobra.Command) error {
 	log.Info().Msg("Executing sync command")
 
 	packageId := config.GetString(cmd, "package-id")
-	gitRepoDir := config.GetDirectory(cmd, "dir-git-repo")
-	artifactsDir := config.GetDirectoryWithDefault(cmd, "dir-artifacts", gitRepoDir)
-	workDir := config.GetDirectory(cmd, "dir-work")
+	gitRepoDir, err := config.GetStringWithEnvExpand(cmd, "dir-git-repo")
+	if err != nil {
+		return fmt.Errorf("security alert for --dir-git-repo: %w", err)
+	}
+	artifactsDir, err := config.GetStringWithEnvExpandWithDefault(cmd, "dir-artifacts", gitRepoDir)
+	if err != nil {
+		return fmt.Errorf("security alert for --dir-artifacts: %w", err)
+	}
+	workDir, err := config.GetStringWithEnvExpand(cmd, "dir-work")
+	if err != nil {
+		return fmt.Errorf("security alert for --dir-work: %w", err)
+	}
 	dirNamingType := config.GetString(cmd, "dir-naming-type")
 	draftHandling := config.GetString(cmd, "draft-handling")
 	includedIds := config.GetStringSlice(cmd, "ids-include")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,9 +40,9 @@ func GetBool(cmd *cobra.Command, flagName string) bool {
 func GetStringWithEnvExpand(cmd *cobra.Command, flagName string) (string, error) {
 	val := os.ExpandEnv(GetString(cmd, flagName))
 
-	isNoSecretsFound, err := validateInputContainsNoSecrets(val)
-	if !isNoSecretsFound {
-		return "", fmt.Errorf("Secrets found in flag %v: %w", flagName, err)
+	isNoSensContFound, err := verifyNoSensitiveContent(val)
+	if !isNoSensContFound {
+		return "", fmt.Errorf("Sensitive content found in flag %v: %w", flagName, err)
 	}
 
 	return val, nil
@@ -51,7 +51,7 @@ func GetStringWithEnvExpand(cmd *cobra.Command, flagName string) (string, error)
 func GetStringWithEnvExpandWithDefault(cmd *cobra.Command, flagName string, defaultValue string) (string, error) {
 	val, err := GetStringWithEnvExpand(cmd, flagName)
 	if err != nil {
-		return "", fmt.Errorf("Secrets found in flag %v: %w", flagName, err)
+		return "", fmt.Errorf("Sensitive content found in flag %v: %w", flagName, err)
 	}
 
 	if val == "" {
@@ -61,17 +61,17 @@ func GetStringWithEnvExpandWithDefault(cmd *cobra.Command, flagName string, defa
 	return val, nil
 }
 
-func validateInputContainsNoSecrets(input string) (bool, error) {
-	secretsConfigParams := []string{
+func verifyNoSensitiveContent(input string) (bool, error) {
+	sensContConfigParams := []string{
 		"tmn-userid",
 		"tmn-password",
 		"oauth-clientid",
 		"oauth-clientsecret",
 	}
 
-	for _, secretsConfigParam := range secretsConfigParams {
-		if viper.IsSet(secretsConfigParam) && strings.Contains(input, viper.GetString(secretsConfigParam)) {
-			return false, fmt.Errorf("Input contains value of secret configuration parameter %v", secretsConfigParam)
+	for _, sensContConfigParam := range sensContConfigParams {
+		if viper.IsSet(sensContConfigParam) && strings.Contains(input, viper.GetString(sensContConfigParam)) {
+			return false, fmt.Errorf("Input contains sensitive content from configuration parameter %v", sensContConfigParam)
 		}
 	}
 


### PR DESCRIPTION
If the values of configuration parameters contain references to environment variables, and these values would reveal secrets after shell expansion, then shell expansion should be prevented to avoid potential security risks.

The following configuration parameters are considered to contain secrets:
- tmn-userid
- tmn-password
- oauth-clientid
- oauth-clientsecret